### PR TITLE
Bugfix iron select inputs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,6 +40,9 @@
     "gold-cc-input": "~1.0.7",
     "gold-zip-input": "~1.0.5",
     "iron-demo-helpers": "~1.2.3",
-    "paper-toggle-button": "~1.1.2"
+    "paper-toggle-button": "~1.1.2",
+    "paper-dropdown-menu": "^1.2.2",
+    "paper-listbox": "^1.1.2",
+    "paper-menu": "^1.2.2"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -31,9 +31,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
 		<link rel="import" href="../../iron-form/iron-form.html">
 		<link rel="import" href="../../paper-button/paper-button.html">
-		<link rel="import" href="../../paper-toggle-button/paper-toggle-button.html">
+		<link rel="import" href="../../paper-dropdown-menu/paper-dropdown-menu.html">
 		<link rel="import" href="../../paper-input/paper-input.html">
 		<link rel="import" href="../../paper-input/paper-textarea.html">
+		<link rel="import" href="../../paper-item/paper-item.html">
+		<link rel="import" href="../../paper-listbox/paper-listbox.html">
+		<link rel="import" href="../../paper-toggle-button/paper-toggle-button.html">
     <link rel="import" href="../paper-steps.html">
     <link rel="import" href="../paper-step.html">
     <style>
@@ -85,6 +88,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <h2>Setup Monthly Subscription</h2>
             <form is="iron-form" method="post"  action="http://posttestserver.com/post.php?dir=paper-steps&dump&sleep=1">
               <paper-input name="name" label="Name" required></paper-input>
+              <paper-dropdown-menu name="type" label="Card Type" required>
+                <paper-listbox class="dropdown-content">
+                  <paper-item>Visa</paper-item>
+                  <paper-item>Master Card</paper-item>
+                  <paper-item>Discover</paper-item>
+                  <paper-item>Amex</paper-item>
+                </paper-listbox>
+              </paper-dropdown-menu>
               <gold-cc-input name="card" label="Card" auto-validate required></gold-cc-input>
               <gold-cc-expiration-input name="expiration" label="Expiration" required></gold-cc-expiration-input>
             </form>

--- a/paper-step.js
+++ b/paper-step.js
@@ -184,6 +184,7 @@ Polymer({
         child = children[i];
         this.listen(child, 'keyup', '_onChange');
       }
+      this.listen(form, 'iron-activate', '_onActivate');
     }
   },
 
@@ -246,6 +247,18 @@ Polymer({
     return 'icons:check';
     // return 'image:brightness-1';
   },
+  /**
+   * Event handler to ignore form elements which trigger any iron-select
+   * events.
+   */
+  _onActivate: function(e) {
+    //ignore iron-selector events from form children
+    e.stopPropagation();
+  },
+  /**
+   * Event handler to change the completed state of a `paper-step` once
+   * any form inputs are changed.
+   */
   _onChange: function(e) {
     if (this.completed) {
       this.completed = false;

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -16,6 +16,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
     <link rel="import" href="../../iron-form/iron-form.html">
+    <link rel="import" href="../../paper-dropdown-menu/paper-dropdown-menu.html">
+    <link rel="import" href="../../paper-item/paper-item.html">
+    <link rel="import" href="../../paper-listbox/paper-listbox.html">
 
     <!-- Step 1: import the element to test -->
     <link rel="import" href="../paper-steps.html">
@@ -63,6 +66,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <form is="iron-form" id="test_form" method="post"
               action="http://posttestserver.com/post.php?dir=paper-steps">
               <paper-input name="test-step-1" label="Test"></paper-input>
+            </form>
+          </paper-step>
+          <paper-step label="step 2">
+            <form is="iron-form" id="test_form" method="post"
+              action="http://posttestserver.com/post.php?dir=paper-steps">
+              <paper-input name="test-step-2" label="Test"></paper-input>
+            </form>
+          </paper-step>
+        </paper-steps>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="paper-steps-iron-selectors">
+      <template>
+        <paper-steps linear>
+          <paper-step label="step 1" optional editable>
+            <form is="iron-form" id="test_form" method="post"
+              action="http://posttestserver.com/post.php?dir=paper-steps">
+              <paper-dropdown-menu name="items" label="Select a item" required>
+                <paper-listbox id="selector" class="dropdown-content">
+                  <paper-item>Item 1</paper-item>
+                  <paper-item>Item 2</paper-item>
+                  <paper-item>Item 3</paper-item>
+                  <paper-item>Item 4</paper-item>
+                </paper-listbox>
+              </paper-dropdown-menu>
             </form>
           </paper-step>
           <paper-step label="step 2">

--- a/test/tests.js
+++ b/test/tests.js
@@ -201,8 +201,6 @@ suite('<paper-steps> events', function() {
         expect(item.data).to.be.equal(item._getForm().serialize());
         expect(item.lastErrorResponse).to.be.undefined;
         expect(item.lastSuccessResponse).to.be.not.ok;
-        // item.async(function() {
-        // }, 500);
       },
       function() {
         selector.select(0);
@@ -267,6 +265,31 @@ suite('<paper-steps> events', function() {
       },
     ]);
 
+  });
+});
+
+suite('<paper-steps> with iron-selector inputs', function() {
+
+  setup(function() {
+    el = item = form = null;
+    i = len = 0;
+    steps = fixture('paper-steps-iron-selectors');
+    items = steps.$.steps_content.items;
+    _items = steps.$.selector.$$('template').items; //horizontal
+    form = items[0].$.step_content.querySelector('form[is="iron-form"]');
+    item = items[0];
+  });
+
+  test('ignores inputs which implement iron-slector behavior', function() {
+    var triggered = false;
+    steps.addEventListener('iron-activate', function(e) {
+      triggered = true;
+    });
+
+    steps.$.selector.select(1);
+    expect(triggered).to.be.equal(false);
+    expect(steps.$.selector.selected).to.be.equal(1);
+    // debugger;
   });
 });
 


### PR DESCRIPTION
Fixes #23 

There are a number of form elements which use the `iron-selector` behaviors, and these get blocked on `iron-activate` by `paper-steps` because the current `paper-step` is incomplete.

This adds a handler to the `iron-form` which stops `iron-activate` from propagating up above the form, which allows form inputs to be selected and manage their own selected states. 